### PR TITLE
(docs): fix instructions in ReadMe to correctly use CLI command and PUBLIC_ prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ This starter uses [SvelteKit](https://kit.svelte.dev/) for the frontend and [San
 The following commands are meant to be run in **both** the `/app` and `/studio` folders.
 
 1. `npm install` to install dependencies
-2. `npm create sanity@latest init --env`, this will:
+2. `npx -y sanity@latest init --env`, this will:
 
-- ask you to select or create a Sanity project and dataset
+- ask you to select or create a Sanity project and dataset, use the same Sanity project and dataset in both folders.
 - output a `.env` file with appropriate variables
 - _(or use `sanity init --env` if you have the CLI installed)_
 
+4. Prefix your environment variables in the SvelteKit `/app` folder with `PUBLIC_`, they should be `PUBLIC_SANITY_DATASET` and `PUBLIC_SANITY_PROJECT_ID`.
 3. `npm run dev` to start the development server
 
 Your SvelteKit app should now be running on [http://localhost:5173/](http://localhost:5173/) and Studio on [http://localhost:3333/](http://localhost:3333/).


### PR DESCRIPTION
Closes #14 

Fairly straight forward PR - I tried to be as minimal as possible in the instructions, hopefully not too minimal.

As mentioned in the issue there is some special sauce that happens in SvelteKit with the `PUBLIC_` prefix so that needs to remain from what I can tell.  You can see a bit of an explainer about this here: https://www.okupter.com/blog/environment-variables-in-sveltekit

I noticed that there is something in the CLI that autodetects Sanity as the Framework and adds the `SANITY_STUDIO` prefix.  I wonder if there is something that can be done on the CLI side to detect SvelteKit and add the proper prefixs as well. That would be a bigger PR to another area of the org, but just something I noticed which would be a nice quality of life improvement for SvelteKit users.