### PR TITLE
remove unused ibm-plex-mono font

### DIFF
--- a/app/src/app.html
+++ b/app/src/app.html
@@ -10,7 +10,7 @@
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link
-			href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@500;700&family=Inter:wght@500;700;800&family=PT+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+			href="https://fonts.googleapis.com/css2?family=Inter:wght@500;700;800&family=PT+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap"
 			rel="stylesheet"
 		/>
 

--- a/app/static/global.css
+++ b/app/static/global.css
@@ -13,7 +13,6 @@
 
 	--font-family-sans: Inter;
 	--font-family-serif: PT Serif;
-	--font-family-mono: IMB Plex Mono;
 
 	--font-size-0: 12px;
 	--font-size-1: 14px;


### PR DESCRIPTION
The font is not used anywhere in the repo but it's definition so it should be removed.
--font-family-mono also had a typo which left me wondering for a bit:

--font-family-mono: ~~IMB~~ **IBM** Plex Mono;
