### PR TITLE
fix: update vite config to support css files

### DIFF
--- a/sveltekit-app/vite.config.ts
+++ b/sveltekit-app/vite.config.ts
@@ -3,4 +3,7 @@ import {defineConfig} from 'vite'
 
 export default defineConfig({
   plugins: [sveltekit()],
+  ssr: {
+    noExternal: ['sanity'],
+  },
 })


### PR DESCRIPTION
### Description

Starting with `sanity@5.23.0`, the `sanity` npm package's main entry (`lib/index.js`) imports its extracted vanilla-extract CSS at the top:

```js
import './bundle.css'
```

This works for browser-side bundling (Vite, webpack, rollup all understand CSS), but breaks SvelteKit's SSR step: SvelteKit pre-renders pages by evaluating the module graph in **Node**, and Node has no loader for `.css` files. The result is a hard build failure:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".css" for
  /…/node_modules/sanity/lib/bundle.css
```

### What to review

- `sveltekit-app/vite.config.ts` — single one-line addition: `ssr: { noExternal: ['sanity'] }`

### Testing

1. Fresh clone of the template
2. `npm install`
3. `npm --workspace sveltekit-app run build` — should complete without `ERR_UNKNOWN_FILE_EXTENSION`
4. `npm --workspace sveltekit-app run dev` — should start without errors and render pages
